### PR TITLE
(chore): make some constants public

### DIFF
--- a/src/fatfs.zig
+++ b/src/fatfs.zig
@@ -282,8 +282,8 @@ pub const FileInfo = struct {
         return std.mem.sliceTo(&self.altname_buffer, 0);
     }
 
-    const max_name_len = if (@hasDecl(c, "FF_LFN_BUF")) c.FF_LFN_BUF else 12;
-    const max_altname_len = if (@hasDecl(c, "FF_SFN_BUF")) c.FF_SFN_BUF else 0;
+    pub const max_name_len = if (@hasDecl(c, "FF_LFN_BUF")) c.FF_LFN_BUF else 12;
+    pub const max_altname_len = if (@hasDecl(c, "FF_SFN_BUF")) c.FF_SFN_BUF else 0;
 
     pub fn format(info: FileInfo, fmt: []const u8, options: std.fmt.FormatOptions, writer: anytype) !void {
         _ = fmt;


### PR DESCRIPTION
Tiny change allowing users to allocate a buffer of the right size to store names, namely: `var names: [n_names][fatfs.FileInfo.max_name_len]`