### PR TITLE
fix for `**Module` instead of `*Module`

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -144,7 +144,7 @@ pub fn build(b: *std.Build) void {
     });
     zfat_lib.installHeader(b.path("src/fatfs/ff.h"), "ff.h");
     zfat_lib.installHeader(b.path("src/fatfs/diskio.h"), "diskio.h");
-    initialize_mod(b, &zfat_lib.root_module, config, link_libc);
+    initialize_mod(b, zfat_lib.root_module, config, link_libc);
 
     const zfat_mod = b.addModule("zfat", .{
         .root_source_file = b.path("src/fatfs.zig"),


### PR DESCRIPTION
Introduced by zig's 3aa802090436a1882fc2093cf0ff8e906340bfcb (as far as i can tell)

PS: Typo in branch's name, it's called `mastet` not `master` :P